### PR TITLE
Feature/fix crash `Fatal error: each layout item may only occur once`

### DIFF
--- a/Sources/SwiftUICharts/BarsView.swift
+++ b/Sources/SwiftUICharts/BarsView.swift
@@ -44,7 +44,7 @@ struct BarsView: View {
                 }
 
                 HStack(alignment: .bottom, spacing: dataPoints.count > 40 ? 0 : 2) {
-                    ForEach(dataPoints.filter(\.visible), id: \.self) { bar in
+                    ForEach(dataPoints.filter(\.visible)) { bar in
                         Capsule(style: .continuous)
                             .fill(bar.legend.color)
                             .accessibilityLabel(Text(bar.label))

--- a/Sources/SwiftUICharts/HorizontalBarChartView.swift
+++ b/Sources/SwiftUICharts/HorizontalBarChartView.swift
@@ -33,7 +33,7 @@ public struct HorizontalBarChartView: View {
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            ForEach(dataPoints, id: \.self) { bar in
+            ForEach(dataPoints) { bar in
                 #if os(watchOS)
                 VStack(alignment: .leading) {
                     RoundedRectangle(cornerRadius: 8, style: .continuous)

--- a/Sources/SwiftUICharts/LegendView.swift
+++ b/Sources/SwiftUICharts/LegendView.swift
@@ -16,7 +16,7 @@ struct LegendView: View {
 
     var body: some View {
         LazyVGrid(columns: [.init(.adaptive(minimum: 100))], alignment: .leading) {
-            ForEach(legends, id: \.color) { legend in
+            ForEach(legends) { legend in
                 HStack(alignment: .center) {
                     Circle()
                         .fill(legend.color)

--- a/Sources/SwiftUICharts/Model/DataPoint.swift
+++ b/Sources/SwiftUICharts/Model/DataPoint.swift
@@ -8,10 +8,11 @@
 import SwiftUI
 
 /// The type that describes the group of data points in the chart.
-public struct Legend {
-    let color: Color
-    let label: LocalizedStringKey
-    let order: Int
+public struct Legend: Identifiable {
+    public let id: UUID = .init()
+    public let color: Color
+    public let label: LocalizedStringKey
+    public let order: Int
 
     /**
      Creates new legend with the following parameters.
@@ -41,7 +42,8 @@ extension Legend: Hashable {
 }
 
 /// The type that describes a data point in the chart.
-public struct DataPoint {
+public struct DataPoint: Identifiable {
+    public let id: UUID = .init()
     public let value: Double
     public let label: LocalizedStringKey
     public let legend: Legend


### PR DESCRIPTION
Library crash in case you add 2 chart views with the same DataPoints due to ForEach `\.id` being used.

Same apply with Legend object if same colour is used in different Legends object.

I reckon this is a specific use case but shall not make SwiftUI crash at run time.

I fix the problem by adding DataPoint and Legend conformance to `Identifiable` protocol