### PR TITLE
Feature/add layout options

### DIFF
--- a/Sources/SwiftUICharts/AxisView.swift
+++ b/Sources/SwiftUICharts/AxisView.swift
@@ -9,18 +9,19 @@ import SwiftUI
 
 struct AxisView: View {
     let dataPoints: [DataPoint]
+    let axisColor: Color
 
     var body: some View {
         VStack {
             dataPoints.max().map {
                 Text(String(Int($0.value)))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(axisColor)
                     .font(.caption)
             }
             Spacer()
             dataPoints.max().map {
                 Text(String(Int($0.value / 2)))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(axisColor)
                     .font(.caption)
             }
             Spacer()
@@ -31,7 +32,7 @@ struct AxisView: View {
 #if DEBUG
 struct AxisView_Previews: PreviewProvider {
     static var previews: some View {
-        AxisView(dataPoints: DataPoint.mock)
+        AxisView(dataPoints: DataPoint.mock, axisColor: .secondary)
     }
 }
 #endif

--- a/Sources/SwiftUICharts/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChartView.swift
@@ -14,6 +14,7 @@ public struct BarChartView: View {
     let barMinHeight: CGFloat
     let showAxis: Bool
     let axisColor: Color
+    let axisLeadingPadding: CGFloat
     let showLabels: Bool
     let labelCount: Int?
     let showLegends: Bool
@@ -27,6 +28,7 @@ public struct BarChartView: View {
         - barMinHeight: The minimal height for the bar that presents the biggest value. Default is 100.
         - showAxis: Bool value that controls whenever to show axis.
         - axisColor: Axis and labels color. Default is `.secondary`
+        - axisLeadingPadding: Leading padding value for axis.        
         - showLabels: Bool value that controls whenever to show labels.
         - labelCount: The count of labels that should be shown below the chart. Default is dataPoints.count unless you specify a value.
         - showLegends: Bool value that controls whenever to show legends.
@@ -37,6 +39,7 @@ public struct BarChartView: View {
         barMinHeight: CGFloat = 100,
         showAxis: Bool = true,
         axisColor: Color = .secondary,
+        axisLeadingPadding: CGFloat = 0,
         showLabels: Bool = true,
         labelCount: Int? = nil,
         showLegends: Bool = true
@@ -46,6 +49,7 @@ public struct BarChartView: View {
         self.barMinHeight = barMinHeight
         self.showAxis = showAxis
         self.axisColor = axisColor
+        self.axisLeadingPadding = axisLeadingPadding
         self.showLabels = showLabels
         self.labelCount = labelCount
         self.showLegends = showLegends
@@ -59,12 +63,16 @@ public struct BarChartView: View {
 
                 if showAxis {
                     AxisView(dataPoints: dataPoints, axisColor: axisColor)
+                        .padding(.leading, axisLeadingPadding)
                         .fixedSize(horizontal: true, vertical: false)
                         .accessibilityHidden(true)
                 }
             }
             if showLabels {
-                LabelsView(dataPoints: dataPoints, axisColor: axisColor, labelCount: labelCount ?? dataPoints.count)
+                LabelsView(dataPoints: dataPoints,
+                           axisColor: axisColor,
+                           padding: axisLeadingPadding,
+                           labelCount: labelCount ?? dataPoints.count)
                     .accessibilityHidden(true)
             }
             if showLegends {

--- a/Sources/SwiftUICharts/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChartView.swift
@@ -26,6 +26,7 @@ public struct BarChartView: View {
         - limit: The horizontal line that will be drawn over bars. Default is nil.
         - barMinHeight: The minimal height for the bar that presents the biggest value. Default is 100.
         - showAxis: Bool value that controls whenever to show axis.
+        - axisColor: Axis and labels color. Default is `.secondary`
         - showLabels: Bool value that controls whenever to show labels.
         - labelCount: The count of labels that should be shown below the chart. Default is dataPoints.count unless you specify a value.
         - showLegends: Bool value that controls whenever to show legends.

--- a/Sources/SwiftUICharts/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChartView.swift
@@ -27,7 +27,6 @@ public struct BarChartView: View {
         - limit: The horizontal line that will be drawn over bars. Default is nil.
         - barMinHeight: The minimal height for the bar that presents the biggest value. Default is 100.
         - showAxis: Bool value that controls whenever to show axis.
-        - axisLeadingPadding: Leading padding value for axis.
         - axisColor: Axis and labels color. Default is `.secondary`
         - axisLeadingPadding: Leading padding value for axis.        
         - showLabels: Bool value that controls whenever to show labels.

--- a/Sources/SwiftUICharts/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChartView.swift
@@ -13,6 +13,7 @@ public struct BarChartView: View {
     let limit: DataPoint?
     let barMinHeight: CGFloat
     let showAxis: Bool
+    let axisColor: Color
     let showLabels: Bool
     let labelCount: Int
     let showLegends: Bool
@@ -26,7 +27,7 @@ public struct BarChartView: View {
         - barMinHeight: The minimal height for the bar that presents the biggest value. Default is 100.
         - showAxis: Bool value that controls whenever to show axis.
         - showLabels: Bool value that controls whenever to show labels.
-        - labelCount: The count of labels that should be shown below the chart.
+        - labelCount: The count of labels that should be shown below the chart. Default is dataPoints.count unless you specify a value.
         - showLegends: Bool value that controls whenever to show legends.
      */
     public init(
@@ -34,6 +35,7 @@ public struct BarChartView: View {
         limit: DataPoint? = nil,
         barMinHeight: CGFloat = 100,
         showAxis: Bool = true,
+        axisColor: Color = .secondary,
         showLabels: Bool = true,
         labelCount: Int = 3,
         showLegends: Bool = true
@@ -42,6 +44,7 @@ public struct BarChartView: View {
         self.limit = limit
         self.barMinHeight = barMinHeight
         self.showAxis = showAxis
+        self.axisColor = axisColor
         self.showLabels = showLabels
         self.labelCount = labelCount
         self.showLegends = showLegends
@@ -50,17 +53,17 @@ public struct BarChartView: View {
     public var body: some View {
         VStack {
             HStack(spacing: 0) {
-                BarsView(dataPoints: dataPoints, limit: limit, showAxis: showAxis)
+                BarsView(dataPoints: dataPoints, limit: limit, showAxis: showAxis, axisColor: axisColor)
                     .frame(minHeight: barMinHeight)
 
                 if showAxis {
-                    AxisView(dataPoints: dataPoints)
+                    AxisView(dataPoints: dataPoints, axisColor: axisColor)
                         .fixedSize(horizontal: true, vertical: false)
                         .accessibilityHidden(true)
                 }
             }
             if showLabels {
-                LabelsView(dataPoints: dataPoints, labelCount: labelCount)
+                LabelsView(dataPoints: dataPoints, axisColor: axisColor, labelCount: labelCount)
                     .accessibilityHidden(true)
             }
             if showLegends {

--- a/Sources/SwiftUICharts/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChartView.swift
@@ -14,6 +14,7 @@ public struct BarChartView: View {
     let barMinHeight: CGFloat
     let showAxis: Bool
     let axisColor: Color
+    let axisLeadingPadding: CGFloat
     let showLabels: Bool
     let labelCount: Int?
     let showLegends: Bool
@@ -26,6 +27,7 @@ public struct BarChartView: View {
         - limit: The horizontal line that will be drawn over bars. Default is nil.
         - barMinHeight: The minimal height for the bar that presents the biggest value. Default is 100.
         - showAxis: Bool value that controls whenever to show axis.
+        - axisLeadingPadding: Leading padding value for axis.
         - axisColor: Axis and labels color. Default is `.secondary`
         - showLabels: Bool value that controls whenever to show labels.
         - labelCount: The count of labels that should be shown below the chart. Default is dataPoints.count unless you specify a value.
@@ -37,6 +39,7 @@ public struct BarChartView: View {
         barMinHeight: CGFloat = 100,
         showAxis: Bool = true,
         axisColor: Color = .secondary,
+        axisLeadingPadding: CGFloat = 0,
         showLabels: Bool = true,
         labelCount: Int? = nil,
         showLegends: Bool = true
@@ -46,6 +49,7 @@ public struct BarChartView: View {
         self.barMinHeight = barMinHeight
         self.showAxis = showAxis
         self.axisColor = axisColor
+        self.axisLeadingPadding = axisLeadingPadding
         self.showLabels = showLabels
         self.labelCount = labelCount
         self.showLegends = showLegends
@@ -59,6 +63,7 @@ public struct BarChartView: View {
 
                 if showAxis {
                     AxisView(dataPoints: dataPoints, axisColor: axisColor)
+                        .padding(.leading, axisLeadingPadding)
                         .fixedSize(horizontal: true, vertical: false)
                         .accessibilityHidden(true)
                 }

--- a/Sources/SwiftUICharts/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChartView.swift
@@ -15,7 +15,7 @@ public struct BarChartView: View {
     let showAxis: Bool
     let axisColor: Color
     let showLabels: Bool
-    let labelCount: Int
+    let labelCount: Int?
     let showLegends: Bool
 
     /**
@@ -37,7 +37,7 @@ public struct BarChartView: View {
         showAxis: Bool = true,
         axisColor: Color = .secondary,
         showLabels: Bool = true,
-        labelCount: Int = 3,
+        labelCount: Int? = nil,
         showLegends: Bool = true
     ) {
         self.dataPoints = dataPoints
@@ -63,7 +63,7 @@ public struct BarChartView: View {
                 }
             }
             if showLabels {
-                LabelsView(dataPoints: dataPoints, axisColor: axisColor, labelCount: labelCount)
+                LabelsView(dataPoints: dataPoints, axisColor: axisColor, labelCount: labelCount ?? dataPoints.count)
                     .accessibilityHidden(true)
             }
             if showLegends {

--- a/Sources/SwiftUICharts/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChartView.swift
@@ -59,8 +59,17 @@ public struct BarChartView: View {
     public var body: some View {
         VStack {
             HStack(spacing: 0) {
-                BarsView(dataPoints: dataPoints, limit: limit, showAxis: showAxis, axisColor: axisColor)
-                    .frame(minHeight: barMinHeight)
+                VStack {
+                    BarsView(dataPoints: dataPoints, limit: limit, showAxis: showAxis, axisColor: axisColor)
+                        .frame(minHeight: barMinHeight)
+
+                    if showLabels {
+                        LabelsView(dataPoints: dataPoints,
+                                   axisColor: axisColor,
+                                   labelCount: labelCount ?? dataPoints.count)
+                            .accessibilityHidden(true)
+                    }
+                }
 
                 if showAxis {
                     AxisView(dataPoints: dataPoints, axisColor: axisColor)
@@ -68,13 +77,6 @@ public struct BarChartView: View {
                         .fixedSize(horizontal: true, vertical: false)
                         .accessibilityHidden(true)
                 }
-            }
-            if showLabels {
-                LabelsView(dataPoints: dataPoints,
-                           axisColor: axisColor,
-                           padding: axisLeadingPadding,
-                           labelCount: labelCount ?? dataPoints.count)
-                    .accessibilityHidden(true)
             }
             if showLegends {
                 LegendView(dataPoints: limit.map { [$0] + dataPoints} ?? dataPoints)

--- a/Sources/SwiftUICharts/BarsView.swift
+++ b/Sources/SwiftUICharts/BarsView.swift
@@ -11,6 +11,7 @@ struct BarsView: View {
     let dataPoints: [DataPoint]
     let limit: DataPoint?
     let showAxis: Bool
+    let axisColor: Color
 
     private var max: Double {
         guard let max = dataPoints.max()?.value, max != 0 else {
@@ -22,7 +23,7 @@ struct BarsView: View {
     private var grid: some View {
         ChartGrid(dataPoints: dataPoints)
             .stroke(
-                Color.secondary,
+                axisColor,
                 style: StrokeStyle(
                     lineWidth: 1,
                     lineCap: .round,
@@ -73,7 +74,7 @@ struct BarsView: View {
 #if DEBUG
 struct BarsView_Previews: PreviewProvider {
     static var previews: some View {
-        BarsView(dataPoints: DataPoint.mock, limit: nil, showAxis: true)
+        BarsView(dataPoints: DataPoint.mock, limit: nil, showAxis: true, axisColor: .secondary)
     }
 }
 #endif

--- a/Sources/SwiftUICharts/BarsView.swift
+++ b/Sources/SwiftUICharts/BarsView.swift
@@ -44,7 +44,7 @@ struct BarsView: View {
                 }
 
                 HStack(alignment: .bottom, spacing: dataPoints.count > 40 ? 0 : 2) {
-                    ForEach(dataPoints.filter(\.visible), id: \.self) { bar in
+                    ForEach(dataPoints.filter(\.visible)) { bar in
                         Capsule(style: .continuous)
                             .fill(bar.legend.color)
                             .accessibilityLabel(Text(bar.label))

--- a/Sources/SwiftUICharts/HorizontalBarChartView.swift
+++ b/Sources/SwiftUICharts/HorizontalBarChartView.swift
@@ -33,7 +33,7 @@ public struct HorizontalBarChartView: View {
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            ForEach(dataPoints, id: \.self) { bar in
+            ForEach(dataPoints) { bar in
                 #if os(watchOS)
                 VStack(alignment: .leading) {
                     RoundedRectangle(cornerRadius: 8, style: .continuous)

--- a/Sources/SwiftUICharts/LabelsView.swift
+++ b/Sources/SwiftUICharts/LabelsView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct LabelsView: View {
     let dataPoints: [DataPoint]
     let axisColor: Color
-    let padding: CGFloat
     
     var labelCount = 3
 
@@ -20,15 +19,16 @@ struct LabelsView: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
-            ForEach(dataPoints.indexed(), id: \.1.self) { index, bar in
-                if index % self.threshold == 0 {
-                    Text(bar.label)
-                        .multilineTextAlignment(.center)
-                        .foregroundColor(axisColor)
-                        .font(.caption)
-                        .padding(.top, padding)
-                    Spacer()
+        GeometryReader { geometry in
+            HStack(spacing: 0) {
+                ForEach(dataPoints.indexed(), id: \.1.self) { index, bar in
+                    if index % self.threshold == 0 {
+                        Text(bar.label)
+                            .multilineTextAlignment(.center)
+                            .foregroundColor(axisColor)
+                            .font(.caption)
+                            .frame(width: geometry.size.width / CGFloat(labelCount), alignment: .center)
+                    }
                 }
             }
         }
@@ -38,7 +38,7 @@ struct LabelsView: View {
 #if DEBUG
 struct LabelsView_Previews: PreviewProvider {
     static var previews: some View {
-        LabelsView(dataPoints: DataPoint.mock, axisColor: .secondary, padding: 0)
+        LabelsView(dataPoints: DataPoint.mock, axisColor: .secondary)
     }
 }
 #endif

--- a/Sources/SwiftUICharts/LabelsView.swift
+++ b/Sources/SwiftUICharts/LabelsView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct LabelsView: View {
     let dataPoints: [DataPoint]
+    let axisColor: Color
     var labelCount = 3
 
     private var threshold: Int {
@@ -22,7 +23,7 @@ struct LabelsView: View {
                 if index % self.threshold == 0 {
                     Text(bar.label)
                         .multilineTextAlignment(.center)
-                        .foregroundColor(.secondary)
+                        .foregroundColor(axisColor)
                         .font(.caption)
                     Spacer()
                 }
@@ -34,7 +35,7 @@ struct LabelsView: View {
 #if DEBUG
 struct LabelsView_Previews: PreviewProvider {
     static var previews: some View {
-        LabelsView(dataPoints: DataPoint.mock)
+        LabelsView(dataPoints: DataPoint.mock, axisColor: .secondary)
     }
 }
 #endif

--- a/Sources/SwiftUICharts/LabelsView.swift
+++ b/Sources/SwiftUICharts/LabelsView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct LabelsView: View {
     let dataPoints: [DataPoint]
     let axisColor: Color
+    let padding: CGFloat
+    
     var labelCount = 3
 
     private var threshold: Int {
@@ -25,6 +27,8 @@ struct LabelsView: View {
                         .multilineTextAlignment(.center)
                         .foregroundColor(axisColor)
                         .font(.caption)
+                        .padding(.top, padding)
+                        .rotationEffect(.degrees(-45))
                     Spacer()
                 }
             }
@@ -35,7 +39,7 @@ struct LabelsView: View {
 #if DEBUG
 struct LabelsView_Previews: PreviewProvider {
     static var previews: some View {
-        LabelsView(dataPoints: DataPoint.mock, axisColor: .secondary)
+        LabelsView(dataPoints: DataPoint.mock, axisColor: .secondary, padding: 0)
     }
 }
 #endif

--- a/Sources/SwiftUICharts/LabelsView.swift
+++ b/Sources/SwiftUICharts/LabelsView.swift
@@ -28,7 +28,6 @@ struct LabelsView: View {
                         .foregroundColor(axisColor)
                         .font(.caption)
                         .padding(.top, padding)
-                        .rotationEffect(.degrees(-45))
                     Spacer()
                 }
             }

--- a/Sources/SwiftUICharts/LegendView.swift
+++ b/Sources/SwiftUICharts/LegendView.swift
@@ -16,7 +16,7 @@ struct LegendView: View {
 
     var body: some View {
         LazyVGrid(columns: [.init(.adaptive(minimum: 100))], alignment: .leading) {
-            ForEach(legends, id: \.color) { legend in
+            ForEach(legends) { legend in
                 HStack(alignment: .center) {
                     Circle()
                         .fill(legend.color)

--- a/Sources/SwiftUICharts/LineChartView.swift
+++ b/Sources/SwiftUICharts/LineChartView.swift
@@ -97,7 +97,6 @@ public struct LineChartView: View {
             if showLabels {
                 LabelsView(dataPoints: dataPoints,
                            axisColor: axisColor,
-                           padding: axisLeadingPadding,
                            labelCount: labelCount)
                     .accessibilityHidden(true)
             }

--- a/Sources/SwiftUICharts/LineChartView.swift
+++ b/Sources/SwiftUICharts/LineChartView.swift
@@ -13,6 +13,7 @@ public struct LineChartView: View {
     let lineMinHeight: CGFloat
     let showAxis: Bool
     let axisColor: Color
+    let axisLeadingPadding: CGFloat
     let showLabels: Bool
     let labelCount: Int
     let showLegends: Bool
@@ -24,6 +25,8 @@ public struct LineChartView: View {
         - dataPoints: The array of data points that will be used to draw the bar chart.
         - lineMinHeight: The minimal height for the point that presents the biggest value. Default is 100.
         - showAxis: Bool value that controls whenever to show axis.
+        - axisColor: Axis and labels color. Default is `.secondary`
+        - axisLeadingPadding: Leading padding value for axis.
         - showLabels: Bool value that controls whenever to show labels.
         - labelCount: The count of labels that should be shown below the the chart.
         - showLegends: Bool value that controls whenever to show legends.
@@ -33,6 +36,7 @@ public struct LineChartView: View {
         lineMinHeight: CGFloat = 100,
         showAxis: Bool = true,
         axisColor: Color = .secondary,
+        axisLeadingPadding: CGFloat = 0,
         showLabels: Bool = true,
         labelCount: Int = 3,
         showLegends: Bool = true
@@ -41,6 +45,7 @@ public struct LineChartView: View {
         self.lineMinHeight = lineMinHeight
         self.showAxis = showAxis
         self.axisColor = axisColor
+        self.axisLeadingPadding = axisLeadingPadding
         self.showLabels = showLabels
         self.labelCount = labelCount
         self.showLegends = showLegends
@@ -90,7 +95,10 @@ public struct LineChartView: View {
                 }
             }
             if showLabels {
-                LabelsView(dataPoints: dataPoints, axisColor: axisColor, labelCount: labelCount)
+                LabelsView(dataPoints: dataPoints,
+                           axisColor: axisColor,
+                           padding: axisLeadingPadding,
+                           labelCount: labelCount)
                     .accessibilityHidden(true)
             }
 

--- a/Sources/SwiftUICharts/LineChartView.swift
+++ b/Sources/SwiftUICharts/LineChartView.swift
@@ -12,6 +12,7 @@ public struct LineChartView: View {
     let dataPoints: [DataPoint]
     let lineMinHeight: CGFloat
     let showAxis: Bool
+    let axisColor: Color
     let showLabels: Bool
     let labelCount: Int
     let showLegends: Bool
@@ -31,6 +32,7 @@ public struct LineChartView: View {
         dataPoints: [DataPoint],
         lineMinHeight: CGFloat = 100,
         showAxis: Bool = true,
+        axisColor: Color = .secondary,
         showLabels: Bool = true,
         labelCount: Int = 3,
         showLegends: Bool = true
@@ -38,6 +40,7 @@ public struct LineChartView: View {
         self.dataPoints = dataPoints
         self.lineMinHeight = lineMinHeight
         self.showAxis = showAxis
+        self.axisColor = axisColor
         self.showLabels = showLabels
         self.labelCount = labelCount
         self.showLegends = showLegends
@@ -55,7 +58,7 @@ public struct LineChartView: View {
     private var grid: some View {
         ChartGrid(dataPoints: dataPoints)
             .stroke(
-                Color.secondary,
+                axisColor,
                 style: StrokeStyle(
                     lineWidth: 1,
                     lineCap: .round,
@@ -82,12 +85,12 @@ public struct LineChartView: View {
                         .frame(minHeight: lineMinHeight)
                 }
                 if showAxis {
-                    AxisView(dataPoints: dataPoints)
+                    AxisView(dataPoints: dataPoints, axisColor: axisColor)
                         .accessibilityHidden(true)
                 }
             }
             if showLabels {
-                LabelsView(dataPoints: dataPoints, labelCount: labelCount)
+                LabelsView(dataPoints: dataPoints, axisColor: axisColor, labelCount: labelCount)
                     .accessibilityHidden(true)
             }
 

--- a/Sources/SwiftUICharts/LineChartView.swift
+++ b/Sources/SwiftUICharts/LineChartView.swift
@@ -15,7 +15,7 @@ public struct LineChartView: View {
     let axisColor: Color
     let axisLeadingPadding: CGFloat
     let showLabels: Bool
-    let labelCount: Int
+    let labelCount: Int?
     let showLegends: Bool
 
     /**
@@ -28,7 +28,7 @@ public struct LineChartView: View {
         - axisColor: Axis and labels color. Default is `.secondary`
         - axisLeadingPadding: Leading padding value for axis.
         - showLabels: Bool value that controls whenever to show labels.
-        - labelCount: The count of labels that should be shown below the the chart.
+        - labelCount: The count of labels that should be shown below the chart. Default is dataPoints.count unless you specify a value.
         - showLegends: Bool value that controls whenever to show legends.
      */
     public init(
@@ -38,7 +38,7 @@ public struct LineChartView: View {
         axisColor: Color = .secondary,
         axisLeadingPadding: CGFloat = 0,
         showLabels: Bool = true,
-        labelCount: Int = 3,
+        labelCount: Int? = nil,
         showLegends: Bool = true
     ) {
         self.dataPoints = dataPoints
@@ -91,18 +91,21 @@ public struct LineChartView: View {
                 }
                 if showAxis {
                     AxisView(dataPoints: dataPoints, axisColor: axisColor)
+                        .padding(.leading, axisLeadingPadding)
+                        .fixedSize(horizontal: true, vertical: false)
                         .accessibilityHidden(true)
                 }
             }
             if showLabels {
                 LabelsView(dataPoints: dataPoints,
                            axisColor: axisColor,
-                           labelCount: labelCount)
+                           labelCount: labelCount ?? dataPoints.count)
                     .accessibilityHidden(true)
             }
 
             if showLegends {
                 LegendView(dataPoints: dataPoints)
+                    .padding()
                     .accessibilityHidden(true)
             }
         }

--- a/Sources/SwiftUICharts/Model/DataPoint.swift
+++ b/Sources/SwiftUICharts/Model/DataPoint.swift
@@ -8,10 +8,11 @@
 import SwiftUI
 
 /// The type that describes the group of data points in the chart.
-public struct Legend {
-    let color: Color
-    let label: LocalizedStringKey
-    let order: Int
+public struct Legend: Identifiable {
+    public let id: UUID = .init()
+    public let color: Color
+    public let label: LocalizedStringKey
+    public let order: Int
 
     /**
      Creates new legend with the following parameters.
@@ -41,7 +42,8 @@ extension Legend: Hashable {
 }
 
 /// The type that describes a data point in the chart.
-public struct DataPoint {
+public struct DataPoint: Identifiable {
+    public let id: UUID = .init()
     public let value: Double
     public let label: LocalizedStringKey
     public let legend: Legend


### PR DESCRIPTION
Add some customisation options:

- Change `labelCount` being optional.
Default is dataPoints.count unless you specify a value.

- Add `axisColor` property to be able to define the grid and axis data accordingly to specific design
Default is `.secondary` unless you specify a custom colour value.

- Add `axisLeadingPadding` property to provide some room if necessary.
Default is `0` unless you specify a custom value.