### PR TITLE
Add options to style the bars views and fix label position

### DIFF
--- a/Sources/SwiftUICharts/AxisView.swift
+++ b/Sources/SwiftUICharts/AxisView.swift
@@ -9,19 +9,21 @@ import SwiftUI
 
 struct AxisView: View {
     let dataPoints: [DataPoint]
+    let labelColor: Color
+    let labelFont: Font
 
     var body: some View {
         VStack {
             dataPoints.max().map {
                 Text(String(Int($0.value)))
-                    .foregroundColor(.accentColor)
-                    .font(.caption)
+                    .foregroundColor(labelColor)
+                    .font(labelFont)
             }
             Spacer()
             dataPoints.max().map {
                 Text(String(Int($0.value / 2)))
-                    .foregroundColor(.accentColor)
-                    .font(.caption)
+                    .foregroundColor(labelColor)
+                    .font(labelFont)
             }
             Spacer()
         }
@@ -31,7 +33,7 @@ struct AxisView: View {
 #if DEBUG
 struct AxisView_Previews: PreviewProvider {
     static var previews: some View {
-        AxisView(dataPoints: DataPoint.mock)
+        AxisView(dataPoints: DataPoint.mock, labelColor: .accentColor, labelFont: .caption)
     }
 }
 #endif

--- a/Sources/SwiftUICharts/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChartView.swift
@@ -12,7 +12,11 @@ public struct BarChartStyle: ChartStyle {
     public let barMinHeight: CGFloat
     public let showAxis: Bool
     public let axisLeadingPadding: CGFloat
+    public let showGrid: Bool
+    public let gridColor: Color
     public let showLabels: Bool
+    public let labelFont: Font
+    public let labelColor: Color
     public let labelCount: Int?
     public let showLegends: Bool
     public let barsCornerRadius: CGFloat
@@ -35,7 +39,11 @@ public struct BarChartStyle: ChartStyle {
         barMinHeight: CGFloat = 100,
         showAxis: Bool = true,
         axisLeadingPadding: CGFloat = 0,
+        showGrid: Bool = true,
+        gridColor: Color = .accentColor,
         showLabels: Bool = true,
+        labelFont: Font = .caption,
+        labelColor: Color = .accentColor,
         labelCount: Int? = nil,
         showLegends: Bool = true,
         barsCornerRadius: CGFloat = 5.0,
@@ -44,7 +52,11 @@ public struct BarChartStyle: ChartStyle {
         self.barMinHeight = barMinHeight
         self.showAxis = showAxis
         self.axisLeadingPadding = axisLeadingPadding
+        self.showGrid = showGrid
+        self.gridColor = gridColor
         self.showLabels = showLabels
+        self.labelFont = labelFont
+        self.labelColor = labelColor
         self.labelCount = labelCount
         self.showLegends = showLegends
         self.barsCornerRadius = barsCornerRadius
@@ -78,7 +90,7 @@ public struct BarChartView: View {
     private var grid: some View {
         ChartGrid(dataPoints: dataPoints)
             .stroke(
-                style.showAxis ? Color.accentColor : .clear,
+                style.showGrid ? style.gridColor : .clear,
                 style: StrokeStyle(
                     lineWidth: 1,
                     lineCap: .round,
@@ -101,7 +113,9 @@ public struct BarChartView: View {
                     if style.showLabels {
                         LabelsView(
                             dataPoints: dataPoints,
-                            labelCount: style.labelCount ?? dataPoints.count
+                            labelCount: style.labelCount ?? dataPoints.count,
+                            labelFont: style.labelFont,
+                            labelColor: style.labelColor
                         ).accessibilityHidden(true)
                     }
                 }

--- a/Sources/SwiftUICharts/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChartView.swift
@@ -9,9 +9,17 @@ import SwiftUI
 
 /// Type that defines a bar chart style.
 public struct BarChartStyle: ChartStyle {
+    
+    public enum AxisPosition {
+        case leading
+        case trailing
+        case hidden
+    }
+
+    public var showAxis: Bool = true
     public let barMinHeight: CGFloat
-    public let showAxis: Bool
-    public let axisLeadingPadding: CGFloat
+    public let axisPosition: AxisPosition
+    public let axisPadding: CGFloat
     public let showGrid: Bool
     public let gridColor: Color
     public let showLabels: Bool
@@ -27,8 +35,8 @@ public struct BarChartStyle: ChartStyle {
 
      - Parameters:
         - barMinHeight: The minimal height for the bar that presents the biggest value. Default is 100.
-        - showAxis: Bool value that controls whenever to show axis.
-        - axisLeadingPadding: Leading padding for axis line. Default is 0.
+        - axisPosition: AxisPosition the position on the axis
+        - axisPadding: CGFloat padding for axis line. Default is 0.
         - showLabels: Bool value that controls whenever to show labels.
         - labelCount: The count of labels that should be shown below the chart. Default is all.
         - showLegends: Bool value that controls whenever to show legends.
@@ -37,7 +45,7 @@ public struct BarChartStyle: ChartStyle {
      */
     public init(
         barMinHeight: CGFloat = 100,
-        showAxis: Bool = true,
+        axisPosition: AxisPosition = .trailing,
         axisLeadingPadding: CGFloat = 0,
         showGrid: Bool = true,
         gridColor: Color = .accentColor,
@@ -50,8 +58,8 @@ public struct BarChartStyle: ChartStyle {
         barsCorners: UIRectCorner = []
     ) {
         self.barMinHeight = barMinHeight
-        self.showAxis = showAxis
-        self.axisLeadingPadding = axisLeadingPadding
+        self.axisPosition = axisPosition
+        self.axisPadding = axisLeadingPadding
         self.showGrid = showGrid
         self.gridColor = gridColor
         self.showLabels = showLabels
@@ -105,8 +113,15 @@ public struct BarChartView: View {
     public var body: some View {
         VStack {
             HStack(spacing: 0) {
+                if style.axisPosition == .leading {
+                    AxisView(dataPoints: dataPoints, labelColor: style.labelColor, labelFont: style.labelFont)
+                        .fixedSize(horizontal: true, vertical: false)
+                        .accessibilityHidden(true)
+                        .padding(.trailing, style.axisPadding)
+                }
+
                 VStack {
-                    BarsView(dataPoints: dataPoints, limit: limit, showAxis: style.showAxis, barsCornerRadius: style.barsCornerRadius, barsCorners: style.barsCorners)
+                    BarsView(dataPoints: dataPoints, limit: limit, showAxis: style.axisPosition != .hidden, barsCornerRadius: style.barsCornerRadius, barsCorners: style.barsCorners)
                         .frame(minHeight: style.barMinHeight)
                         .background(grid)
 
@@ -119,11 +134,11 @@ public struct BarChartView: View {
                         ).accessibilityHidden(true)
                     }
                 }
-                if style.showAxis {
-                    AxisView(dataPoints: dataPoints)
+                if style.axisPosition == .trailing {
+                    AxisView(dataPoints: dataPoints, labelColor: style.labelColor, labelFont: style.labelFont)
                         .fixedSize(horizontal: true, vertical: false)
                         .accessibilityHidden(true)
-                        .padding(.leading, style.axisLeadingPadding)
+                        .padding(.leading, style.axisPadding)
                 }
             }
 

--- a/Sources/SwiftUICharts/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChartView.swift
@@ -49,7 +49,6 @@ public struct BarChartStyle: ChartStyle {
         self.showLegends = showLegends
         self.barsCornerRadius = barsCornerRadius
         self.barsCorners = barsCorners
-        print(barsCornerRadius)
     }
 }
 

--- a/Sources/SwiftUICharts/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChartView.swift
@@ -15,6 +15,9 @@ public struct BarChartStyle: ChartStyle {
     public let showLabels: Bool
     public let labelCount: Int?
     public let showLegends: Bool
+    public let barsCornerRadius: CGFloat
+    public let barsCorners: UIRectCorner
+
     /**
      Creates new bar chart style with the following parameters.
 
@@ -25,6 +28,8 @@ public struct BarChartStyle: ChartStyle {
         - showLabels: Bool value that controls whenever to show labels.
         - labelCount: The count of labels that should be shown below the chart. Default is all.
         - showLegends: Bool value that controls whenever to show legends.
+        - barsCornerRadius: CGFloat value that controls corner radius of the bars
+        - barsCorners: UIRectCorner value that controls what corners should get a radius
      */
     public init(
         barMinHeight: CGFloat = 100,
@@ -32,7 +37,9 @@ public struct BarChartStyle: ChartStyle {
         axisLeadingPadding: CGFloat = 0,
         showLabels: Bool = true,
         labelCount: Int? = nil,
-        showLegends: Bool = true
+        showLegends: Bool = true,
+        barsCornerRadius: CGFloat = 5.0,
+        barsCorners: UIRectCorner = []
     ) {
         self.barMinHeight = barMinHeight
         self.showAxis = showAxis
@@ -40,6 +47,9 @@ public struct BarChartStyle: ChartStyle {
         self.showLabels = showLabels
         self.labelCount = labelCount
         self.showLegends = showLegends
+        self.barsCornerRadius = barsCornerRadius
+        self.barsCorners = barsCorners
+        print(barsCornerRadius)
     }
 }
 
@@ -85,7 +95,7 @@ public struct BarChartView: View {
         VStack {
             HStack(spacing: 0) {
                 VStack {
-                    BarsView(dataPoints: dataPoints, limit: limit, showAxis: style.showAxis)
+                    BarsView(dataPoints: dataPoints, limit: limit, showAxis: style.showAxis, barsCornerRadius: style.barsCornerRadius, barsCorners: style.barsCorners)
                         .frame(minHeight: style.barMinHeight)
                         .background(grid)
 

--- a/Sources/SwiftUICharts/BarsView.swift
+++ b/Sources/SwiftUICharts/BarsView.swift
@@ -11,6 +11,8 @@ struct BarsView: View {
     let dataPoints: [DataPoint]
     let limit: DataPoint?
     let showAxis: Bool
+    let barsCornerRadius: CGFloat
+    let barsCorners: UIRectCorner
 
     private var max: Double {
         guard let max = dataPoints.max()?.value, max != 0 else {
@@ -24,8 +26,9 @@ struct BarsView: View {
             ZStack(alignment: .bottomTrailing) {
                 HStack(alignment: .bottom, spacing: dataPoints.count > 40 ? 0 : 2) {
                     ForEach(dataPoints.filter(\.visible), id: \.self) { bar in
-                        Capsule(style: .continuous)
+                        Rectangle()
                             .fill(bar.legend.color)
+                            .cornerRadius(barsCornerRadius, corners: barsCorners)
                             .accessibilityLabel(Text(bar.label))
                             .accessibilityValue(Text(bar.legend.label))
                             .frame(height: CGFloat(bar.value / self.max) * geometry.size.height)
@@ -52,7 +55,7 @@ struct BarsView: View {
 #if DEBUG
 struct BarsView_Previews: PreviewProvider {
     static var previews: some View {
-        BarsView(dataPoints: DataPoint.mock, limit: nil, showAxis: true)
+        BarsView(dataPoints: DataPoint.mock, limit: nil, showAxis: true, barsCornerRadius: 0.0, barsCorners: [])
     }
 }
 #endif

--- a/Sources/SwiftUICharts/Extensions/CornerRadiusViewModifier.swift
+++ b/Sources/SwiftUICharts/Extensions/CornerRadiusViewModifier.swift
@@ -1,0 +1,25 @@
+//
+//  CornerRadiusViewModifier.swift
+//  
+//
+//  Created by Stefan Sturm on 18.12.20.
+//
+
+import SwiftUI
+
+extension View {
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape( RoundedCorner(radius: radius, corners: corners) )
+    }
+}
+
+struct RoundedCorner: Shape {
+
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
+}

--- a/Sources/SwiftUICharts/LabelsView.swift
+++ b/Sources/SwiftUICharts/LabelsView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct LabelsView: View {
     let dataPoints: [DataPoint]
     let labelCount: Int
+    let labelFont: Font
+    let labelColor: Color
 
     private var threshold: Int {
         let threshold = Double(dataPoints.count) / Double(labelCount)
@@ -22,8 +24,8 @@ struct LabelsView: View {
                 if index % self.threshold == 0 {
                     Text(bar.label)
                         .multilineTextAlignment(.center)
-                        .foregroundColor(.accentColor)
-                        .font(.caption)
+                        .foregroundColor(labelColor)
+                        .font(labelFont)
                         .frame(minWidth: 0, maxWidth: .infinity)
                 }
             }
@@ -34,7 +36,7 @@ struct LabelsView: View {
 #if DEBUG
 struct LabelsView_Previews: PreviewProvider {
     static var previews: some View {
-        LabelsView(dataPoints: DataPoint.mock, labelCount: 3)
+        LabelsView(dataPoints: DataPoint.mock, labelCount: 3, labelFont: .caption, labelColor: .accentColor)
     }
 }
 #endif

--- a/Sources/SwiftUICharts/LabelsView.swift
+++ b/Sources/SwiftUICharts/LabelsView.swift
@@ -24,7 +24,7 @@ struct LabelsView: View {
                         .multilineTextAlignment(.center)
                         .foregroundColor(.accentColor)
                         .font(.caption)
-                    Spacer()
+                        .frame(minWidth: 0, maxWidth: .infinity)
                 }
             }
         }

--- a/Sources/SwiftUICharts/LineChartView.swift
+++ b/Sources/SwiftUICharts/LineChartView.swift
@@ -104,7 +104,7 @@ public struct LineChartView: View {
             }
 
             if style.showLabels {
-                LabelsView(dataPoints: dataPoints, labelCount: style.labelCount ?? dataPoints.count)
+                LabelsView(dataPoints: dataPoints, labelCount: style.labelCount ?? dataPoints.count, labelFont: .caption, labelColor: .accentColor)
                     .accessibilityHidden(true)
             }
 

--- a/Sources/SwiftUICharts/LineChartView.swift
+++ b/Sources/SwiftUICharts/LineChartView.swift
@@ -97,7 +97,7 @@ public struct LineChartView: View {
                     .background(grid)
 
                 if style.showAxis {
-                    AxisView(dataPoints: dataPoints)
+                    AxisView(dataPoints: dataPoints, labelColor: .accentColor, labelFont: .caption)
                         .accessibilityHidden(true)
                         .padding(.leading, style.axisLeadingPadding)
                 }


### PR DESCRIPTION
I added two options to the *BarChartStyle*:
        - barsCornerRadius: CGFloat value that controls corner radius of the bars
        - barsCorners: UIRectCorner value that controls what corners should get a radius

With this you can better customize the bars view. Just Capsule() wasn't that nice ;)

And it fixes a bug, that the labels where not centered unter the bars