### PR TITLE
Some improvements to HorizontalBarChartView

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/SwiftUICharts/HorizontalBarChartView.swift
+++ b/Sources/SwiftUICharts/HorizontalBarChartView.swift
@@ -13,6 +13,7 @@ public struct HorizontalBarChartView: View {
     let dataPoints: [DataPoint]
     let barMaxWidth: CGFloat
 	let text: ((_ bar: DataPoint) -> Text)?
+	let maxValue: Double
 	
 	@ScaledMetric private var barHeight: CGFloat = 17
 	@ScaledMetric private var circleSize: CGFloat = 8
@@ -23,19 +24,14 @@ public struct HorizontalBarChartView: View {
      - Parameters:
         - dataPoints: The array of data points that will be used to draw the bar chart.
         - barMaxWidth: The maximal width for the bar that presents the biggest value. Default is 100.
+		- maxValue: The max value for calculating the bar width. Default is max value from the dataPoints.
 		- text: The text to be shown next to the bar. Default is: bar.legend.label + ", " + bar.label
      */
-    public init(dataPoints: [DataPoint], barMaxWidth: CGFloat = 100, text: ((_ bar: DataPoint) -> Text)? = nil) {
+	public init(dataPoints: [DataPoint], barMaxWidth: CGFloat = 100, maxValue: Double? = nil, text: ((_ bar: DataPoint) -> Text)? = nil) {
         self.dataPoints = dataPoints
         self.barMaxWidth = barMaxWidth
 		self.text = text
-    }
-
-    private var max: Double {
-        guard let max = dataPoints.max()?.value, max != 0 else {
-            return 1
-        }
-        return max
+		self.maxValue = max(maxValue ?? 1, dataPoints.max()?.value ?? 1)
     }
 
     public var body: some View {
@@ -45,7 +41,7 @@ public struct HorizontalBarChartView: View {
                 VStack(alignment: .leading) {
 					Capsule()
                         .foregroundColor(bar.legend.color)
-                        .frame(width: CGFloat(bar.value / self.max) * barMaxWidth, height: barHeight)
+                        .frame(width: CGFloat(bar.value / maxValue) * barMaxWidth, height: barHeight)
                     HStack {
                         Circle()
                             .foregroundColor(bar.legend.color)
@@ -65,7 +61,7 @@ public struct HorizontalBarChartView: View {
                 HStack {
 					Capsule()
                         .foregroundColor(bar.legend.color)
-                        .frame(width: CGFloat(bar.value / self.max) * barMaxWidth, height: barHeight)
+                        .frame(width: CGFloat(bar.value / maxValue) * barMaxWidth, height: barHeight)
 
                     Circle()
                         .foregroundColor(bar.legend.color)

--- a/Sources/SwiftUICharts/HorizontalBarChartView.swift
+++ b/Sources/SwiftUICharts/HorizontalBarChartView.swift
@@ -49,7 +49,7 @@ public struct HorizontalBarChartView: View {
                     HStack {
                         Circle()
                             .foregroundColor(bar.legend.color)
-                            .frame(width: legendCircleSize, height: circleSize)
+                            .frame(width: circleSize, height: circleSize)
 
 						Group {
 							if let text = text?(bar) {

--- a/Sources/SwiftUICharts/HorizontalBarChartView.swift
+++ b/Sources/SwiftUICharts/HorizontalBarChartView.swift
@@ -9,8 +9,13 @@ import SwiftUI
 
 /// SwiftUI view that draws bars by placing them into a vertical container.
 public struct HorizontalBarChartView: View {
+	
     let dataPoints: [DataPoint]
     let barMaxWidth: CGFloat
+	let text: ((_ bar: DataPoint) -> Text)?
+	
+	@ScaledMetric private var barHeight: CGFloat = 17
+	@ScaledMetric private var circleSize: CGFloat = 8
 
     /**
      Creates new horizontal bar chart with the following parameters.
@@ -18,10 +23,12 @@ public struct HorizontalBarChartView: View {
      - Parameters:
         - dataPoints: The array of data points that will be used to draw the bar chart.
         - barMaxWidth: The maximal width for the bar that presents the biggest value. Default is 100.
+		- text: The text to be shown next to the bar. Default is: bar.legend.label + ", " + bar.label
      */
-    public init(dataPoints: [DataPoint], barMaxWidth: CGFloat = 100) {
+    public init(dataPoints: [DataPoint], barMaxWidth: CGFloat = 100, text: ((_ bar: DataPoint) -> Text)? = nil) {
         self.dataPoints = dataPoints
         self.barMaxWidth = barMaxWidth
+		self.text = text
     }
 
     private var max: Double {
@@ -36,34 +43,42 @@ public struct HorizontalBarChartView: View {
             ForEach(dataPoints, id: \.self) { bar in
                 #if os(watchOS)
                 VStack(alignment: .leading) {
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+					Capsule()
                         .foregroundColor(bar.legend.color)
-                        .frame(width: CGFloat(bar.value / self.max) * barMaxWidth, height: 16)
+                        .frame(width: CGFloat(bar.value / self.max) * barMaxWidth, height: barHeight)
                     HStack {
                         Circle()
                             .foregroundColor(bar.legend.color)
-                            .frame(width: 8, height: 8)
+                            .frame(width: legendCircleSize, height: circleSize)
 
-                        Text(bar.legend.label) + Text(", ") + Text(bar.label)
-
-                        // TODO: temp fix
-                        Spacer()
+						Group {
+							if let text = text?(bar) {
+								text
+							} else {
+								Text(bar.legend.label) + Text(", ") + Text(bar.label)
+							}
+						}
+						.frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
                 #else
                 HStack {
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+					Capsule()
                         .foregroundColor(bar.legend.color)
-                        .frame(width: CGFloat(bar.value / self.max) * barMaxWidth, height: 16)
+                        .frame(width: CGFloat(bar.value / self.max) * barMaxWidth, height: barHeight)
 
                     Circle()
                         .foregroundColor(bar.legend.color)
-                        .frame(width: 8, height: 8)
+                        .frame(width: circleSize, height: circleSize)
 
-                    Text(bar.legend.label) + Text(", ") + Text(bar.label)
-
-                    // TODO: temp fix
-                    Spacer()
+					Group {
+						if let text = text?(bar) {
+							text
+						} else {
+							Text(bar.legend.label) + Text(", ") + Text(bar.label)
+						}
+					}
+					.frame(maxWidth: .infinity, alignment: .leading)
                 }
                 #endif
             }

--- a/Sources/SwiftUICharts/Model/DataPoint.swift
+++ b/Sources/SwiftUICharts/Model/DataPoint.swift
@@ -38,6 +38,10 @@ extension Legend: Hashable {
     public func hash(into hasher: inout Hasher) {
         hasher.combine(color)
     }
+	
+	public static func ==(lhs: Legend, rhs: Legend) -> Bool {
+		return lhs.color == rhs.color
+	}
 }
 
 /// The type that describes a data point in the chart.
@@ -69,6 +73,10 @@ extension DataPoint: Hashable {
         hasher.combine(legend)
         hasher.combine(value)
     }
+	
+	public static func ==(lhs: DataPoint, rhs: DataPoint) -> Bool {
+		return lhs.legend == rhs.legend && lhs.value == rhs.value
+	}
 }
 
 extension DataPoint: Comparable {

--- a/Sources/SwiftUICharts/Model/DataPoint.swift
+++ b/Sources/SwiftUICharts/Model/DataPoint.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 /// The type that describes the group of data points in the chart.
 public struct Legend {
-    let color: Color
-    let label: LocalizedStringKey
-    let order: Int
+	public let color: Color
+	public let label: LocalizedStringKey
+	public let order: Int
 
     /**
      Creates new legend with the following parameters.


### PR DESCRIPTION
Improvements (based on my own needs):

- Supports custom text to show next to the bars (in my case I needed a different text than the default provided).
- Adjusts the height and size of the bars and circles, respectively, when the size of the dynamic font changes.
- Allows setting the max value for calculating the bar width (in my case I needed charts with different dataPoints to have a normalised width regardless of the max values of those dataPoints).

I also changed RoundedRectangle by Capsule to guarantee the rounded edges no matter the height of the bar.

Thanks for sharing SwiftUICharts!