### PR TITLE
Add DataPoint conform to Identifiable

### DIFF
--- a/Sources/SwiftUICharts/Model/DataPoint.swift
+++ b/Sources/SwiftUICharts/Model/DataPoint.swift
@@ -119,6 +119,12 @@ extension DataPoint: Comparable {
     }
 }
 
+extension DataPoint: Identifiable {
+    public var id: UUID {
+        .init()
+    }
+}
+
 #if DEBUG
 extension DataPoint {
     static var mock: [DataPoint] {


### PR DESCRIPTION
Hello

When you use DataPoint with same value and label you get alert like this 

```
ForEach<Array<DataPoint>, DataPoint, ModifiedContent<ModifiedContent<ModifiedContent<_ShapeView<Capsule, Color>, AccessibilityAttachmentModifier>, _OffsetEffect>, _FrameLayout>>: the ID DataPoint(startValue: 0.0, endValue: 6.0, label: SwiftUI.LocalizedStringKey(key: "%@", hasFormatting: true, arguments: [SwiftUI.LocalizedStringKey.FormatArgument(storage: SwiftUI.LocalizedStringKey.FormatArgument.Storage.value("kh", nil))]), legend: SwiftUICharts.Legend(color: blue, label: SwiftUI.LocalizedStringKey(key: "min", hasFormatting: false, arguments: []), order: 0), visible: true) 
occurs multiple times within the collection, this will give undefined results!
```

And app crash sometimes

To resolve this issue I suggest to add conformance to the Identifiable protocol.

I found this PR #3 with this same code suggestion and merged. But the code is no longer present now?